### PR TITLE
47-reverse-exact-match-output-fix

### DIFF
--- a/R/calc_match_person.R
+++ b/R/calc_match_person.R
@@ -164,6 +164,12 @@ calc_match_person <- function(df_one, id_one, forename_one, surname_one, dob_one
         "POSTCODE_ONE" = "POSTCODE_TWO"
       ),
       na_matches = "never"
+    ) |>
+    dplyr::mutate(
+      FORENAME_TWO = FORENAME_ONE,
+      SURNAME_TWO = SURNAME_ONE,
+      DOB_TWO = DOB_ONE,
+      POSTCODE_TWO = POSTCODE_ONE,
     )
 
   # Reverse exact matches
@@ -177,6 +183,12 @@ calc_match_person <- function(df_one, id_one, forename_one, surname_one, dob_one
         "POSTCODE_ONE" = "POSTCODE_TWO"
       ),
       na_matches = "never"
+    ) |>
+    dplyr::mutate(
+      FORENAME_TWO = SURNAME_ONE,
+      SURNAME_TWO = FORENAME_ONE,
+      DOB_TWO = DOB_ONE,
+      POSTCODE_TWO = POSTCODE_ONE,
     )
 
   # Union exact matches
@@ -184,10 +196,6 @@ calc_match_person <- function(df_one, id_one, forename_one, surname_one, dob_one
     dplyr::union_all(exact_matches_reverse) %>%
     dplyr::distinct() %>%
     dplyr::mutate(
-      FORENAME_TWO = FORENAME_ONE,
-      SURNAME_TWO = SURNAME_ONE,
-      DOB_TWO = DOB_ONE,
-      POSTCODE_TWO = POSTCODE_ONE,
       JW_FORENAME = 1,
       JW_SURNAME = 1,
       JW_POSTCODE = 1,

--- a/R/calc_match_person_db.R
+++ b/R/calc_match_person_db.R
@@ -164,6 +164,12 @@ calc_match_person_db <- function(df_one, id_one, forename_one, surname_one, dob_
         "POSTCODE_ONE" = "POSTCODE_TWO"
       ),
       na_matches = "never"
+    ) |>
+    dplyr::mutate(
+      FORENAME_TWO = FORENAME_ONE,
+      SURNAME_TWO = SURNAME_ONE,
+      DOB_TWO = DOB_ONE,
+      POSTCODE_TWO = POSTCODE_ONE,
     )
 
   # Reverse exact matches
@@ -177,6 +183,12 @@ calc_match_person_db <- function(df_one, id_one, forename_one, surname_one, dob_
         "POSTCODE_ONE" = "POSTCODE_TWO"
       ),
       na_matches = "never"
+    ) |>
+    dplyr::mutate(
+      FORENAME_TWO = SURNAME_ONE,
+      SURNAME_TWO = FORENAME_ONE,
+      DOB_TWO = DOB_ONE,
+      POSTCODE_TWO = POSTCODE_ONE,
     )
 
   # Union exact matches
@@ -184,10 +196,6 @@ calc_match_person_db <- function(df_one, id_one, forename_one, surname_one, dob_
     dplyr::union_all(exact_matches_reverse) %>%
     dplyr::distinct() %>%
     dplyr::mutate(
-      FORENAME_TWO = FORENAME_ONE,
-      SURNAME_TWO = SURNAME_ONE,
-      DOB_TWO = DOB_ONE,
-      POSTCODE_TWO = POSTCODE_ONE,
       JW_FORENAME = 1,
       JW_SURNAME = 1,
       JW_POSTCODE = 1,

--- a/R/calc_match_person_self.R
+++ b/R/calc_match_person_self.R
@@ -156,6 +156,12 @@ calc_match_person_self <- function(df, id, forename, surname, dob, postcode,
       ),
       na_matches = "never",
       relationship = "many-to-many"
+    ) |>
+    dplyr::mutate(
+      FORENAME_TWO = FORENAME_ONE,
+      SURNAME_TWO = SURNAME_ONE,
+      DOB_TWO = DOB_ONE,
+      POSTCODE_TWO = POSTCODE_ONE,
     )
 
   # Identify reverse exact matches (forename = surname & surname = forename)
@@ -170,6 +176,12 @@ calc_match_person_self <- function(df, id, forename, surname, dob, postcode,
       ),
       na_matches = "never",
       relationship = "many-to-many"
+    ) |>
+    dplyr::mutate(
+      FORENAME_TWO = SURNAME_ONE,
+      SURNAME_TWO = FORENAME_ONE,
+      DOB_TWO = DOB_ONE,
+      POSTCODE_TWO = POSTCODE_ONE,
     )
 
   # Union exact matches to get a single dataset of matches and format output
@@ -177,10 +189,6 @@ calc_match_person_self <- function(df, id, forename, surname, dob, postcode,
     dplyr::union_all(exact_matches_reverse) |>
     dplyr::distinct() |>
     dplyr::mutate(
-      FORENAME_TWO = FORENAME_ONE,
-      SURNAME_TWO = SURNAME_ONE,
-      DOB_TWO = DOB_ONE,
-      POSTCODE_TWO = POSTCODE_ONE,
       JW_FORENAME = 1,
       JW_SURNAME = 1,
       JW_POSTCODE = 1,

--- a/R/calc_match_person_self_db.R
+++ b/R/calc_match_person_self_db.R
@@ -157,6 +157,12 @@ calc_match_person_self_db <- function(df, id, forename, surname, dob, postcode,
       ),
       na_matches = "never",
       relationship = "many-to-many"
+    ) |>
+    dplyr::mutate(
+      FORENAME_TWO = FORENAME_ONE,
+      SURNAME_TWO = SURNAME_ONE,
+      DOB_TWO = DOB_ONE,
+      POSTCODE_TWO = POSTCODE_ONE,
     )
 
   # Identify reverse exact matches (forename = surname & surname = forename)
@@ -171,6 +177,12 @@ calc_match_person_self_db <- function(df, id, forename, surname, dob, postcode,
       ),
       na_matches = "never",
       relationship = "many-to-many"
+    ) |>
+    dplyr::mutate(
+      FORENAME_TWO = SURNAME_ONE,
+      SURNAME_TWO = FORENAME_ONE,
+      DOB_TWO = DOB_ONE,
+      POSTCODE_TWO = POSTCODE_ONE,
     )
 
   # Union exact matches to get a single dataset of matches and format output
@@ -178,10 +190,6 @@ calc_match_person_self_db <- function(df, id, forename, surname, dob, postcode,
     dplyr::union_all(exact_matches_reverse) |>
     dplyr::distinct() |>
     dplyr::mutate(
-      FORENAME_TWO = FORENAME_ONE,
-      SURNAME_TWO = SURNAME_ONE,
-      DOB_TWO = DOB_ONE,
-      POSTCODE_TWO = POSTCODE_ONE,
       JW_FORENAME = 1,
       JW_SURNAME = 1,
       JW_POSTCODE = 1,


### PR DESCRIPTION
Fixed output so that when a reverse exact match is identified the output will still reflect the input format